### PR TITLE
Fix ludo route entry

### DIFF
--- a/app/(ludo)/index.js
+++ b/app/(ludo)/index.js
@@ -1,9 +1,1 @@
-/**
- * @format
- */
-
-import {AppRegistry} from 'react-native';
-import App from './App';
-import {name as appName} from './app.json';
-
-AppRegistry.registerComponent(appName, () => App);
+export { default } from './App';


### PR DESCRIPTION
## Summary
- remove RN AppRegistry entry and export the Ludo app for expo-router

## Testing
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68821c5663dc8329b0531ce3cd71d1a8